### PR TITLE
feat: load google fonts for typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
     <meta name="color-scheme" content="light only">
     <meta name="theme-color" content="#2563eb" />
     <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;700&family=Inter:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <title>Chef Alerg — MVP</title>
   </head>
   <body class="antialiased bg-slate-50">

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,3 +3,17 @@
 @tailwind utilities;
 
 html, body, #root { height: 100%; }
+
+body {
+  font-family: 'Inter', sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.logo {
+  font-family: 'Baloo 2', cursive;
+}


### PR DESCRIPTION
## Summary
- load Baloo 2 and Inter via Google Fonts in `index.html`
- apply Baloo 2 to headings/logo and Inter to body text

## Testing
- `npm test` *(fails: Element type is invalid: expected a string ...)*

------
https://chatgpt.com/codex/tasks/task_b_6896c62c3370832f865d22c4664b05e2