### PR TITLE
feat: add base theme colors and fonts

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,18 @@
+@import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;700&family=Inter:wght@400;700&family=Nunito:wght@400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 html, body, #root { height: 100%; }
+
+@layer base {
+  body {
+    @apply font-body;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-heading;
+  }
+}
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,23 @@
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: '#4F9DDE',
+        secondary: '#FFD166',
+        success: '#06D6A0',
+        danger: '#EF476F',
+        neutral: {
+          900: '#333333',
+          50: '#FFFFFF',
+        },
+      },
+      fontFamily: {
+        heading: ['"Baloo 2"', 'cursive'],
+        body: ['Inter', 'Nunito', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }
+


### PR DESCRIPTION
## Summary
- extend Tailwind theme with brand colors and semantic font families
- import Baloo 2 and Inter/Nunito fonts in global stylesheet and apply theme tokens

## Testing
- `npm test` *(fails: Element type is invalid: expected a string (for built-in components) or a class/function)*

------
https://chatgpt.com/codex/tasks/task_b_6896c62da1d8832f85a39888000c36ef