### PR TITLE
feat: organize icon assets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,9 @@ import {
   Gamepad2,
 } from "lucide-react";
 import GameCheff from "./GameCheff";
+import MascotIcon from "@/assets/icons/mascot.svg";
+import SearchIcon from "@/assets/icons/search.svg";
+import AlertIcon from "@/assets/icons/alert.svg";
 
 // Utilidades simples
 const cls = (...s: string[]) => s.filter(Boolean).join(" ");
@@ -148,7 +151,7 @@ function Checklists() {
         {Object.keys(CHECKLISTS).map((name) => (
           <Card key={name} onClick={() => setCurrent(name as ChecklistKey)}>
             <div className="flex items-start gap-3">
-              <ListChecks className="text-green-600" />
+              <img src={AlertIcon} alt="" className="w-5 h-5" />
               <div className="flex-1">
                 <div className="flex items-center justify-between">
                   <h3 className="font-semibold">{name}</h3>
@@ -276,8 +279,9 @@ function Rotulometro() {
   if (step === "idle")
     return (
       <div className="text-center">
-        <p className="text-gray-600 mb-3">
-          Aprenda a identificar ingredientes de risco.
+        <p className="text-gray-600 mb-3 flex items-center justify-center gap-1">
+          <img src={SearchIcon} alt="Pesquisar" className="w-4 h-4" />
+          <span>Aprenda a identificar ingredientes de risco.</span>
         </p>
         <Btn onClick={start}>
           <Play className="inline mr-2" /> Começar
@@ -599,8 +603,8 @@ export default function App() {
     <div className="min-h-[100vh] bg-gradient-to-b from-slate-50 to-white">
       <div className="max-w-4xl mx-auto p-4 md:p-6">
         <div className="flex items-center gap-3 mb-6">
-          <div className="p-2 rounded-xl bg-blue-600 text-white">
-            <GraduationCap />
+          <div className="p-2 rounded-xl bg-blue-600">
+            <img src={MascotIcon} alt="Mascote" className="w-6 h-6" />
           </div>
           <div>
             <h1 className="text-2xl md:text-3xl font-bold">CheckGluten</h1>
@@ -728,3 +732,5 @@ export default function App() {
     </div>
   );
 }
+
+export { Checklists, Rotulometro };

--- a/src/assets/icons/alert.svg
+++ b/src/assets/icons/alert.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M32 6 L2 58h60L32 6z" fill="#F87171" stroke="#DC2626" stroke-width="4"/>
+  <line x1="32" y1="24" x2="32" y2="40" stroke="#fff" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="48" r="3" fill="#fff"/>
+</svg>

--- a/src/assets/icons/mascot.svg
+++ b/src/assets/icons/mascot.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#FCD34D" stroke="#FBBF24" stroke-width="4"/>
+  <circle cx="22" cy="26" r="4" fill="#000"/>
+  <circle cx="42" cy="26" r="4" fill="#000"/>
+  <path d="M22 42c4 4 16 4 20 0" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/src/assets/icons/search.svg
+++ b/src/assets/icons/search.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="27" cy="27" r="16" stroke="#000" stroke-width="4" fill="none"/>
+  <line x1="41" y1="41" x2="58" y2="58" stroke="#000" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "strict": true
+    "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": [
     "src"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [react()],
   // Para GitHub Pages web use base: '/chef-alerg-mvp/'
   base: '/',
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary
- add `src/assets/icons` with mascot, search, and alert SVGs
- configure `@` alias and update components to use new icon imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6896c62e28cc832fbd08ed0bd667a1ed