### PR TITLE
feat: apply subtle blue gradient globally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -728,3 +728,5 @@ export default function App() {
     </div>
   );
 }
+
+export { Checklists, Rotulometro };

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const AppLayout: React.FC<Props> = ({ children }) => {
+  return <div className="min-h-screen bg-app-gradient">{children}</div>;
+};
+
+export default AppLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import AppLayout from './AppLayout'
 import './styles.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <AppLayout>
+      <App />
+    </AppLayout>
   </React.StrictMode>,
 )

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,11 @@
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      backgroundImage: {
+        'app-gradient': 'linear-gradient(to bottom, #4F9DDE, #FFFFFF)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add reusable `app-gradient` Tailwind utility
- wrap app with new `AppLayout` to apply gradient background
- export checklist and rotulometro components for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6896c63342b0832faf0b50dca8911c0f